### PR TITLE
feat(conf) add `lmdb_map_size` directive to configure size of the LMD…

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
       with:
         path: |
           /home/runner/work/cache
-        key: ${{ runner.os }}-${{ hashFiles('**/tests.yml') }}-nginx-${{ matrix.nginx }}-openssl-${{ matrix.openssl }}-${{ matrix.fips2 }}-boringssl-${{ matrix.boringssl }}
+        key: ${{ runner.os }}-${{ hashFiles('**/tests.yml') }}-${{ hashFiles('**/*.c', '**/*.h') }}-nginx-${{ matrix.nginx }}-openssl-${{ matrix.openssl }}
 
     - name: Setup tools
       run: |

--- a/src/ngx_lua_resty_lmdb_module.h
+++ b/src/ngx_lua_resty_lmdb_module.h
@@ -10,6 +10,7 @@
 struct ngx_lua_resty_lmdb_conf_s {
     ngx_path_t  *env_path;
     size_t       max_databases;
+    size_t       map_size;
     MDB_env     *env;
     MDB_txn     *ro_txn;
 };

--- a/t/01-sanity.t
+++ b/t/01-sanity.t
@@ -11,6 +11,7 @@ my $pwd = cwd();
 
 our $MainConfig = qq{
     lmdb_environment_path /tmp/test.mdb;
+    lmdb_map_size 5m;
 };
 
 our $HttpConfig = qq{


### PR DESCRIPTION
…B map

By default the map size is limited to 10MB, this option allows user to bump the map size limit to a larger value.