### PR TITLE
feat(*) add encryption support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,5 @@
 [submodule "lmdb"]
 	path = lmdb
-	url = https://github.com/LMDB/lmdb.git
+        url = https://github.com/LMDB/lmdb.git
+        branch = mdb.master3
+

--- a/Makefile.lmdb
+++ b/Makefile.lmdb
@@ -1,0 +1,145 @@
+# Makefile for liblmdb (Lightning memory-mapped database library).
+
+########################################################################
+# Configuration. The compiler options must enable threaded compilation.
+#
+# Preprocessor macros (for CPPFLAGS) of interest...
+# Note that the defaults should already be correct for most
+# platforms; you should not need to change any of these.
+# Read their descriptions in mdb.c if you do:
+#
+# - MDB_USE_POSIX_MUTEX, MDB_USE_POSIX_SEM, MDB_USE_SYSV_SEM
+# - MDB_DSYNC
+# - MDB_FDATASYNC
+# - MDB_FDATASYNC_WORKS
+# - MDB_USE_PWRITEV
+# - MDB_USE_ROBUST
+#
+# There may be other macros in mdb.c of interest. You should
+# read mdb.c before changing any of them.
+#
+CC	= gcc
+AR	= ar
+W	= -W -Wall -Wno-unused-parameter -Wbad-function-cast -Wuninitialized
+THREADS = -pthread
+OPT = -O2 -g
+CFLAGS	= $(THREADS) $(OPT) $(W) $(XCFLAGS)
+LDFLAGS = $(THREADS)
+LDLIBS	= 
+SOLIBS	= 
+SOEXT	= .so
+LDL		= -ldl
+prefix	= /usr/local
+exec_prefix = $(prefix)
+bindir = $(exec_prefix)/bin
+libdir = $(exec_prefix)/lib
+includedir = $(prefix)/include
+datarootdir = $(prefix)/share
+mandir = $(datarootdir)/man
+
+########################################################################
+
+IHDRS	= lmdb.h
+ILIBS	= liblmdb.a chacha8.a liblmdb$(SOEXT)
+IPROGS	= mdb_stat mdb_copy mdb_dump mdb_load mdb_drop
+IDOCS	= mdb_stat.1 mdb_copy.1 mdb_dump.1 mdb_load.1 mdb_drop.1
+PROGS	= $(IPROGS) mtest mtest2 mtest3 mtest4 mtest5
+RPROGS	= mtest_remap mtest_enc mtest_enc2
+
+all:	$(ILIBS) $(PROGS)
+# Requires CPPFLAGS=-DMDB_VL32 and/or -DMDB_RPAGE_CACHE
+rall:	all $(RPROGS)
+
+install: $(ILIBS) $(IPROGS) $(IHDRS)
+	mkdir -p $(DESTDIR)$(bindir)
+	mkdir -p $(DESTDIR)$(libdir)
+	mkdir -p $(DESTDIR)$(includedir)
+	mkdir -p $(DESTDIR)$(mandir)/man1
+	for f in $(IPROGS); do cp $$f $(DESTDIR)$(bindir); done
+	for f in $(ILIBS); do cp $$f $(DESTDIR)$(libdir); done
+	for f in $(IHDRS); do cp $$f $(DESTDIR)$(includedir); done
+	for f in $(IDOCS); do cp $$f $(DESTDIR)$(mandir)/man1; done
+
+clean:
+	rm -rf $(PROGS) $(RPROGS) *.[ao] *.[ls]o *~ testdb
+
+test:	all
+	rm -rf testdb && mkdir testdb
+	./mtest && ./mdb_stat testdb
+
+liblmdb.a:	mdb.o midl.o
+	$(AR) rs $@ mdb.o midl.o
+
+chacha8.a:	chacha8.o
+	$(AR) rs $@ chacha8.o
+
+liblmdb$(SOEXT):	mdb.lo midl.lo
+#	$(CC) $(LDFLAGS) -pthread -shared -Wl,-Bsymbolic -o $@ mdb.o midl.o $(SOLIBS)
+	$(CC) $(LDFLAGS) -pthread -shared -o $@ mdb.lo midl.lo $(SOLIBS)
+
+mdb_stat: mdb_stat.o module.o liblmdb.a
+	$(CC) $(LDFLAGS) -o $@ $^ $(LDL)
+mdb_copy: mdb_copy.o module.o liblmdb.a
+	$(CC) $(LDFLAGS) -o $@ $^ $(LDL)
+mdb_dump: mdb_dump.o module.o liblmdb.a
+	$(CC) $(LDFLAGS) -o $@ $^ $(LDL)
+mdb_load: mdb_load.o module.o liblmdb.a
+	$(CC) $(LDFLAGS) -o $@ $^ $(LDL)
+mdb_drop: mdb_drop.o module.o liblmdb.a
+	$(CC) $(LDFLAGS) -o $@ $^ $(LDL)
+mtest:    mtest.o    liblmdb.a
+mtest2:	mtest2.o liblmdb.a
+mtest3:	mtest3.o liblmdb.a
+mtest4:	mtest4.o liblmdb.a
+mtest5:	mtest5.o liblmdb.a
+mtest6:	mtest6.o liblmdb.a
+mtest_remap:  mtest_remap.o liblmdb.a
+mtest_enc:    mtest_enc.o chacha8.o liblmdb.a
+mtest_enc2:	  mtest_enc2.o module.o liblmdb.a crypto.lm
+	$(CC) $(LDFLAGS) -pthread -o $@ mtest_enc2.o module.o liblmdb.a $(LDL)
+
+crypto.lm:	crypto.c
+	$(CC) -shared -o $@ -lcrypto
+
+mdb.o: mdb.c lmdb.h midl.h
+	$(CC) $(CFLAGS) $(CPPFLAGS) -c mdb.c
+
+chacha8.o: chacha8.c chacha8.h
+	$(CC) $(CFLAGS) $(CPPFLAGS) -c chacha8.c
+
+midl.o: midl.c midl.h
+	$(CC) $(CFLAGS) $(CPPFLAGS) -c midl.c
+
+mdb.lo: mdb.c lmdb.h midl.h
+	$(CC) $(CFLAGS) -fPIC $(CPPFLAGS) -c mdb.c -o $@
+
+midl.lo: midl.c midl.h
+	$(CC) $(CFLAGS) -fPIC $(CPPFLAGS) -c midl.c -o $@
+
+chacha8.lo: chacha8.c chacha8.h
+	$(CC) $(CFLAGS) -fPIC $(CPPFLAGS) -c chacha8.c -o $@
+
+%:	%.o
+	$(CC) $(CFLAGS) $(LDFLAGS) $^ $(LDLIBS) -o $@
+
+%.o:	%.c lmdb.h
+	$(CC) $(CFLAGS) $(CPPFLAGS) -c $<
+
+COV_FLAGS=-fprofile-arcs -ftest-coverage
+COV_OBJS=xmdb.o xmidl.o
+
+coverage: xmtest
+	for i in mtest*.c [0-9]*.c; do j=`basename \$$i .c`; $(MAKE) $$j.o; \
+		gcc -o x$$j $$j.o $(COV_OBJS) -pthread $(COV_FLAGS); \
+		rm -rf testdb; mkdir testdb; ./x$$j; done
+	gcov xmdb.c
+	gcov xmidl.c
+
+xmtest:	mtest.o xmdb.o xmidl.o
+	gcc -o xmtest mtest.o xmdb.o xmidl.o -pthread $(COV_FLAGS)
+
+xmdb.o: mdb.c lmdb.h midl.h
+	$(CC) $(CFLAGS) -fPIC $(CPPFLAGS) -O0 $(COV_FLAGS) -c mdb.c -o $@
+
+xmidl.o: midl.c midl.h
+	$(CC) $(CFLAGS) -fPIC $(CPPFLAGS) -O0 $(COV_FLAGS) -c midl.c -o $@

--- a/config
+++ b/config
@@ -5,7 +5,7 @@ ngx_module_incs="$ngx_addon_dir/lmdb/libraries/liblmdb $ngx_addon_dir/src"
 
 . auto/module
 
-LINK_DEPS="$LINK_DEPS $ngx_addon_dir/lmdb/libraries/liblmdb/liblmdb.a"
-CORE_LIBS="$CORE_LIBS $ngx_addon_dir/lmdb/libraries/liblmdb/liblmdb.a"
+LINK_DEPS="$LINK_DEPS $ngx_addon_dir/lmdb/libraries/liblmdb/liblmdb.a $ngx_addon_dir/lmdb/libraries/liblmdb/chacha8.a"
+CORE_LIBS="$CORE_LIBS $ngx_addon_dir/lmdb/libraries/liblmdb/liblmdb.a $ngx_addon_dir/lmdb/libraries/liblmdb/chacha8.a"
 
 ngx_addon_name=$ngx_module_name

--- a/config.make
+++ b/config.make
@@ -3,7 +3,12 @@ cat <<EOF >>$NGX_MAKEFILE
 
 $ngx_addon_dir/lmdb/libraries/liblmdb/liblmdb.a:
 	echo "Building liblmdb"; \\
-	\$(MAKE) -C $ngx_addon_dir/lmdb/libraries/liblmdb; \\
+	\$(MAKE) -C $ngx_addon_dir/lmdb/libraries/liblmdb -f $ngx_addon_dir/Makefile.lmdb liblmdb.a; \\
 	echo "Finished building liblmdb"
+
+$ngx_addon_dir/lmdb/libraries/liblmdb/chacha8.a:
+	echo "Building chacha8"; \\
+	\$(MAKE) -C $ngx_addon_dir/lmdb/libraries/liblmdb -f $ngx_addon_dir/Makefile.lmdb chacha8.a; \\
+	echo "Finished building chacha8"
 
 EOF

--- a/src/ngx_lua_resty_lmdb_module.c
+++ b/src/ngx_lua_resty_lmdb_module.c
@@ -167,9 +167,7 @@ static ngx_int_t ngx_lua_resty_lmdb_init_worker(ngx_cycle_t *cycle)
         }
 
         char   key[32];
-        size_t bytes_read;
-
-        bytes_read = fread(key, sizeof(char), 32, fp);
+        fread(key, sizeof(char), 32, fp);
 
         fclose(fp);
 

--- a/src/ngx_lua_resty_lmdb_module.c
+++ b/src/ngx_lua_resty_lmdb_module.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include <ngx_lua_resty_lmdb_module.h>
 
 
@@ -15,6 +16,13 @@ static ngx_command_t  ngx_lua_resty_lmdb_commands[] = {
       ngx_conf_set_path_slot,
       0,
       offsetof(ngx_lua_resty_lmdb_conf_t, env_path),
+      NULL },
+
+    { ngx_string("lmdb_encryption_key_file"),
+      NGX_MAIN_CONF|NGX_DIRECT_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_path_slot,
+      0,
+      offsetof(ngx_lua_resty_lmdb_conf_t, key_file),
       NULL },
 
     { ngx_string("lmdb_max_databases"),
@@ -58,6 +66,13 @@ ngx_module_t  ngx_lua_resty_lmdb_module = {
 };
 
 
+static int
+ngx_lua_resty_lmdb_enc_func(const MDB_val* src, MDB_val* dst, const MDB_val* key, int encdec) {
+    chacha8(src->mv_data, src->mv_size, (uint8_t*) key[0].mv_data, (uint8_t*) key[1].mv_data, (char*)dst->mv_data);
+    return 0;
+}
+
+
 static void *
 ngx_lua_resty_lmdb_create_conf(ngx_cycle_t *cycle)
 {
@@ -72,6 +87,7 @@ ngx_lua_resty_lmdb_create_conf(ngx_cycle_t *cycle)
      * set by ngx_pcalloc():
      *
      *     conf->env_path = NULL;
+     *     conf->key_file = NULL;
      *     conf->env = NULL;
      */
 
@@ -137,6 +153,36 @@ static ngx_int_t ngx_lua_resty_lmdb_init_worker(ngx_cycle_t *cycle)
         ngx_log_error(NGX_LOG_CRIT, cycle->log, 0,
                       "unable to set maximum DB count for LMDB");
         return NGX_ERROR;
+    }
+
+    if (lcf->key_file != NULL) {
+        FILE *fp;
+
+        fp = fopen((const char *) lcf->key_file->name.data, "r");
+        if (fp == NULL) {
+            ngx_log_error(NGX_LOG_CRIT, cycle->log, 0,
+                          "unable to read LMDB encryption key from: %s",
+                          (const char *) lcf->key_file->name.data);
+            return NGX_ERROR;
+        }
+
+        char   key[32];
+        size_t bytes_read;
+
+        bytes_read = fread(key, sizeof(char), 32, fp);
+
+        fclose(fp);
+
+        MDB_val enckey;
+        enckey.mv_data = &key[0];
+        enckey.mv_size = 32;
+
+        rc = mdb_env_set_encrypt(lcf->env, ngx_lua_resty_lmdb_enc_func, &enckey, 0);
+        if (rc != 0) {
+            ngx_log_error(NGX_LOG_CRIT, cycle->log, 0,
+                          "unable to set LMDB encryption key: %s", mdb_strerror(rc));
+            return NGX_ERROR;
+        }
     }
 
     rc = mdb_env_open(lcf->env, (const char *) lcf->env_path->name.data, 0, 0600);

--- a/src/ngx_lua_resty_lmdb_module.h
+++ b/src/ngx_lua_resty_lmdb_module.h
@@ -5,10 +5,12 @@
 #include <ngx_config.h>
 #include <ngx_core.h>
 #include <lmdb.h>
+#include <chacha8.h>
 
 
 struct ngx_lua_resty_lmdb_conf_s {
     ngx_path_t  *env_path;
+    ngx_path_t  *key_file;
     size_t       max_databases;
     size_t       map_size;
     MDB_env     *env;


### PR DESCRIPTION
### Summary

- Changes `lmdb` branch to `mdb.master3`
- Adds code to set encryption callback (currently `chacha8.c`/`chacha8.h` that is bundled with `lmdb` repo)

#### TODO:

- change encyption callback to use OpenSSL (check example in `lmdb/crypto.c`).
- boring ssl / fips compliant encryption (aes in gcm mode?)
- do we need to use the lmdb's checksum function or does it have benefits (error handling of wrong keys?), and what are the downsides (slower, slower startups?)
- use nginx native ways of reading the bytes from a file containing encryption key

I cannot push changes to linked `lmdb` repo, but here is what I had to change in the `Makefile` (to build that `chacha8.a`):

```Makefile
# Makefile for liblmdb (Lightning memory-mapped database library).

########################################################################
# Configuration. The compiler options must enable threaded compilation.
#
# Preprocessor macros (for CPPFLAGS) of interest...
# Note that the defaults should already be correct for most
# platforms; you should not need to change any of these.
# Read their descriptions in mdb.c if you do:
#
# - MDB_USE_POSIX_MUTEX, MDB_USE_POSIX_SEM, MDB_USE_SYSV_SEM
# - MDB_DSYNC
# - MDB_FDATASYNC
# - MDB_FDATASYNC_WORKS
# - MDB_USE_PWRITEV
# - MDB_USE_ROBUST
#
# There may be other macros in mdb.c of interest. You should
# read mdb.c before changing any of them.
#
CC	= gcc
AR	= ar
W	= -W -Wall -Wno-unused-parameter -Wbad-function-cast -Wuninitialized
THREADS = -pthread
OPT = -O2 -g
CFLAGS	= $(THREADS) $(OPT) $(W) $(XCFLAGS)
LDFLAGS = $(THREADS)
LDLIBS	= 
SOLIBS	= 
SOEXT	= .so
LDL		= -ldl
prefix	= /usr/local
exec_prefix = $(prefix)
bindir = $(exec_prefix)/bin
libdir = $(exec_prefix)/lib
includedir = $(prefix)/include
datarootdir = $(prefix)/share
mandir = $(datarootdir)/man

########################################################################

IHDRS	= lmdb.h
ILIBS	= liblmdb.a chacha8.a liblmdb$(SOEXT)
IPROGS	= mdb_stat mdb_copy mdb_dump mdb_load mdb_drop
IDOCS	= mdb_stat.1 mdb_copy.1 mdb_dump.1 mdb_load.1 mdb_drop.1
PROGS	= $(IPROGS) mtest mtest2 mtest3 mtest4 mtest5
RPROGS	= mtest_remap mtest_enc mtest_enc2

all:	$(ILIBS) $(PROGS)
# Requires CPPFLAGS=-DMDB_VL32 and/or -DMDB_RPAGE_CACHE
rall:	all $(RPROGS)

install: $(ILIBS) $(IPROGS) $(IHDRS)
	mkdir -p $(DESTDIR)$(bindir)
	mkdir -p $(DESTDIR)$(libdir)
	mkdir -p $(DESTDIR)$(includedir)
	mkdir -p $(DESTDIR)$(mandir)/man1
	for f in $(IPROGS); do cp $$f $(DESTDIR)$(bindir); done
	for f in $(ILIBS); do cp $$f $(DESTDIR)$(libdir); done
	for f in $(IHDRS); do cp $$f $(DESTDIR)$(includedir); done
	for f in $(IDOCS); do cp $$f $(DESTDIR)$(mandir)/man1; done

clean:
	rm -rf $(PROGS) $(RPROGS) *.[ao] *.[ls]o *~ testdb

test:	all
	rm -rf testdb && mkdir testdb
	./mtest && ./mdb_stat testdb

liblmdb.a:	mdb.o midl.o
	$(AR) rs $@ mdb.o midl.o

chacha8.a:	chacha8.o
	$(AR) rs $@ chacha8.o

liblmdb$(SOEXT):	mdb.lo midl.lo
#	$(CC) $(LDFLAGS) -pthread -shared -Wl,-Bsymbolic -o $@ mdb.o midl.o $(SOLIBS)
	$(CC) $(LDFLAGS) -pthread -shared -o $@ mdb.lo midl.lo $(SOLIBS)

mdb_stat: mdb_stat.o module.o liblmdb.a
	$(CC) $(LDFLAGS) -o $@ $^ $(LDL)
mdb_copy: mdb_copy.o module.o liblmdb.a
	$(CC) $(LDFLAGS) -o $@ $^ $(LDL)
mdb_dump: mdb_dump.o module.o liblmdb.a
	$(CC) $(LDFLAGS) -o $@ $^ $(LDL)
mdb_load: mdb_load.o module.o liblmdb.a
	$(CC) $(LDFLAGS) -o $@ $^ $(LDL)
mdb_drop: mdb_drop.o module.o liblmdb.a
	$(CC) $(LDFLAGS) -o $@ $^ $(LDL)
mtest:    mtest.o    liblmdb.a
mtest2:	mtest2.o liblmdb.a
mtest3:	mtest3.o liblmdb.a
mtest4:	mtest4.o liblmdb.a
mtest5:	mtest5.o liblmdb.a
mtest6:	mtest6.o liblmdb.a
mtest_remap:  mtest_remap.o liblmdb.a
mtest_enc:    mtest_enc.o chacha8.o liblmdb.a
mtest_enc2:	  mtest_enc2.o module.o liblmdb.a crypto.lm
	$(CC) $(LDFLAGS) -pthread -o $@ mtest_enc2.o module.o liblmdb.a $(LDL)

crypto.lm:	crypto.c
	$(CC) -shared -o $@ -lcrypto

mdb.o: mdb.c lmdb.h midl.h
	$(CC) $(CFLAGS) $(CPPFLAGS) -c mdb.c

chacha8.o: chacha8.c chacha8.h
	$(CC) $(CFLAGS) $(CPPFLAGS) -c chacha8.c

midl.o: midl.c midl.h
	$(CC) $(CFLAGS) $(CPPFLAGS) -c midl.c

mdb.lo: mdb.c lmdb.h midl.h
	$(CC) $(CFLAGS) -fPIC $(CPPFLAGS) -c mdb.c -o $@

midl.lo: midl.c midl.h
	$(CC) $(CFLAGS) -fPIC $(CPPFLAGS) -c midl.c -o $@

chacha8.lo: chacha8.c chacha8.h
	$(CC) $(CFLAGS) -fPIC $(CPPFLAGS) -c chacha8.c -o $@

%:	%.o
	$(CC) $(CFLAGS) $(LDFLAGS) $^ $(LDLIBS) -o $@

%.o:	%.c lmdb.h
	$(CC) $(CFLAGS) $(CPPFLAGS) -c $<

COV_FLAGS=-fprofile-arcs -ftest-coverage
COV_OBJS=xmdb.o xmidl.o

coverage: xmtest
	for i in mtest*.c [0-9]*.c; do j=`basename \$$i .c`; $(MAKE) $$j.o; \
		gcc -o x$$j $$j.o $(COV_OBJS) -pthread $(COV_FLAGS); \
		rm -rf testdb; mkdir testdb; ./x$$j; done
	gcov xmdb.c
	gcov xmidl.c

xmtest:	mtest.o xmdb.o xmidl.o
	gcc -o xmtest mtest.o xmdb.o xmidl.o -pthread $(COV_FLAGS)

xmdb.o: mdb.c lmdb.h midl.h
	$(CC) $(CFLAGS) -fPIC $(CPPFLAGS) -O0 $(COV_FLAGS) -c mdb.c -o $@

xmidl.o: midl.c midl.h
	$(CC) $(CFLAGS) -fPIC $(CPPFLAGS) -O0 $(COV_FLAGS) -c midl.c -o $@
```


If you want to test this with `lmdb` branch in Kong, here are the changes:

Add in `kong/templates/kong_defaults.lua`:
```ini
lmdb_encryption_key_file = NONE
```

Add in `kong/templates/nginx.lua`:
```nginx
> if lmdb_encryption_key_file then
lmdb_encryption_key_file ${{LMDB_ENCRYPTION_KEY_FILE}};
> end
```

Here is a small test case that then shows that it works:

```sh
# without encryption
pkill nginx
rm /usr/local/kong/dbless.lmdb/*
KONG_DATABASE=off KONG_DECLARATIVE_CONFIG=my.yaml kong restart
cat /usr/local/kong/nginx.conf | grep lmdb
http :8001/routes
cat /usr/local/kong/dbless.lmdb/data.mdb

# with encryption
pkill nginx
rm /usr/local/kong/dbless.lmdb/*
head -c 32 < /dev/urandom > /usr/local/kong/dbless.lmdb/secret
KONG_LMDB_ENCRYPTION_KEY_FILE=/usr/local/kong/dbless.lmdb/secret KONG_DATABASE=off KONG_DECLARATIVE_CONFIG=my.yaml kong restart
cat /usr/local/kong/nginx.conf | grep lmdb
http :8001/routes
cat /usr/local/kong/dbless.lmdb/data.mdb
```