### PR TITLE
chore(build) allow building as dynamic module

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
       with:
         path: |
           /home/runner/work/cache
-        key: ${{ runner.os }}-${{ hashFiles('**/tests.yml') }}-${{ hashFiles('**/*.c', '**/*.h') }}-nginx-${{ matrix.nginx }}-openssl-${{ matrix.openssl }}
+        key: ${{ runner.os }}-${{ hashFiles('**/tests.yml') }}-${{ hashFiles('**/*.c', '**/*.h', 'config', 'config.make') }}-nginx-${{ matrix.nginx }}-openssl-${{ matrix.openssl }}
 
     - name: Setup tools
       run: |

--- a/config
+++ b/config
@@ -2,10 +2,10 @@ ngx_module_type=CORE
 ngx_module_name=ngx_lua_resty_lmdb_module
 ngx_module_srcs="$ngx_addon_dir/src/ngx_lua_resty_lmdb_module.c $ngx_addon_dir/src/ngx_lua_resty_lmdb_transaction.c"
 ngx_module_incs="$ngx_addon_dir/lmdb/libraries/liblmdb $ngx_addon_dir/src"
+ngx_module_libs="$ngx_addon_dir/lmdb/libraries/liblmdb/liblmdb.a"
 
 . auto/module
 
-LINK_DEPS="$LINK_DEPS $ngx_addon_dir/lmdb/libraries/liblmdb/liblmdb.a"
-CORE_LIBS="$CORE_LIBS $ngx_addon_dir/lmdb/libraries/liblmdb/liblmdb.a"
+LINK_DEPS="$LINK_DEPS $ngx_module_libs"
 
 ngx_addon_name=$ngx_module_name

--- a/config.make
+++ b/config.make
@@ -3,7 +3,7 @@ cat <<EOF >>$NGX_MAKEFILE
 
 $ngx_addon_dir/lmdb/libraries/liblmdb/liblmdb.a:
 	echo "Building liblmdb"; \\
-	\$(MAKE) -C $ngx_addon_dir/lmdb/libraries/liblmdb; \\
+	\$(MAKE) XCFLAGS="-fPIC" -C $ngx_addon_dir/lmdb/libraries/liblmdb; \\
 	echo "Finished building liblmdb"
 
 EOF


### PR DESCRIPTION
Adjust the config script so that `liblmdb.a` is linked first with
module.o, instead of nginx object. When building this module as dynamic
module, this fix ensures the statically linked library stays with the
module.so.

Also adding `-fPIC` to lmdb CFLAGS so when it statically linked, the
host (dynamic) library can be dynamically loaded.