### PR TITLE
feat: use key file to encrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ from the `txn` table when `commit()` returned an error is undefined.
 **context:** *main*
 
 Encrypt the lmdb database. Encryption is enabled only when the `lmdb_encryption_key` is set. The
-content of keyfile will be used as the key to encrypt lmdb.
+content of keyfile will be used to derive a the key to encrypt lmdb.
 
 [Back to TOC](#table-of-contents)
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ from the `txn` table when `commit()` returned an error is undefined.
 **context:** *main*
 
 Encrypt the lmdb database. Encryption is enabled only when the `lmdb_encryption_key` is set. The
-content of keyfile will be used to derive a the key to encrypt lmdb.
+content of keyfile will be used to derive a key to encrypt lmdb.
 
 [Back to TOC](#table-of-contents)
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Table of Contents
             * [commit](#commit)
     * [Directives](#Directives)
         * [lmdb_encryption_key](#lmdb_encryption_key)
-        * [lmdb_encryption_type](#lmdb_encryption_type)
+        * [lmdb_encryption_mode](#lmdb_encryption_mode)
     * [Copyright and license](#copyright-and-license)
 
 ## APIs
@@ -178,20 +178,20 @@ from the `txn` table when `commit()` returned an error is undefined.
 
 **context:** *main*
 
-Encrypt the lmdb database. Encryption is enabled only when the lmdb_encryption_key is set. The
+Encrypt the lmdb database. Encryption is enabled only when the `lmdb_encryption_key` is set. The
 content of keyfile will be used as the key to encrypt lmdb.
 
 [Back to TOC](#table-of-contents)
 
-### lmdb_encryption_type
+### lmdb_encryption_mode
 
-**syntax:** *lmdb_encryption_type "aes-256-gcm";*
+**syntax:** *lmdb_encryption_mode "aes-256-gcm";*
 
 **context:** *main*
 
-Set the lmdb database encryption mode. The default encryption mode is aes-256-gcm. The optional encryption
-modes are chacha20-poly1305 and aes-256-gcm. Note that lmdb_encryption_type needs to be set only when
-lmdb_encryption_key is set.
+Set the lmdb database encryption mode. The default encryption mode is "aes-256-gcm". The optional encryption
+modes are "chacha20-poly1305" and "aes-256-gcm". Note that `lmdb_encryption_mode` needs to be set only when
+`lmdb_encryption_key` is set.
 
 [Back to TOC](#table-of-contents)
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Table of Contents
             * [db\_drop](#db_drop)
             * [commit](#commit)
     * [Directives](#Directives)
-        * [lmdb_encryption_key_data](#lmdb_encryption_key_data)
+        * [lmdb_encryption_key](#lmdb_encryption_key)
         * [lmdb_encryption_type](#lmdb_encryption_type)
     * [Copyright and license](#copyright-and-license)
 
@@ -172,14 +172,14 @@ from the `txn` table when `commit()` returned an error is undefined.
 
 ## Directives
 
-### lmdb_encryption_key_data
+### lmdb_encryption_key
 
-**syntax:** *lmdb_encryption_key_data "YourPassword";*
+**syntax:** *lmdb_encryption_key path/to/keyfile;*
 
 **context:** *main*
 
-Encrypt the lmdb database. Encryption is enabled only when the lmdb_encryption_key_data is set. The 
-lmdb_encryption_key_data will be used as the key to encrypt lmdb.
+Encrypt the lmdb database. Encryption is enabled only when the lmdb_encryption_key is set. The
+content of keyfile will be used as the key to encrypt lmdb.
 
 [Back to TOC](#table-of-contents)
 
@@ -189,9 +189,9 @@ lmdb_encryption_key_data will be used as the key to encrypt lmdb.
 
 **context:** *main*
 
-Set the lmdb database encryption mode. The default encryption mode is aes-256-gcm. The optional encryption 
-modes are chacha20-poly1305 and aes-256-gcm. Note that lmdb_encryption_type needs to be set only when 
-lmdb_encryption_key_data is set.
+Set the lmdb database encryption mode. The default encryption mode is aes-256-gcm. The optional encryption
+modes are chacha20-poly1305 and aes-256-gcm. Note that lmdb_encryption_type needs to be set only when
+lmdb_encryption_key is set.
 
 [Back to TOC](#table-of-contents)
 

--- a/src/ngx_lua_resty_lmdb_module.c
+++ b/src/ngx_lua_resty_lmdb_module.c
@@ -1,6 +1,7 @@
 #include <ngx_lua_resty_lmdb_module.h>
 
 
+#define MAX_BUF_LEN         256
 #define ENC_KEY_LEN         32
 
 #ifndef EVP_DIGEST_CONSTANT
@@ -171,6 +172,13 @@ ngx_lua_resty_lmdb_init_conf(ngx_cycle_t *cycle, void *conf)
         }
 
         size = ngx_file_size(&fi);
+
+        if (size > MAX_BUF_LEN) {
+            ngx_log_error(NGX_LOG_CRIT, cycle->log, 0,
+                          "\"%V\" must be less than 256 bytes", &file.name);
+            ngx_close_file(file.fd);
+            return NGX_CONF_ERROR;
+        }
 
         buf = ngx_pcalloc(cycle->pool, size);
         if (buf == NULL) {

--- a/src/ngx_lua_resty_lmdb_module.c
+++ b/src/ngx_lua_resty_lmdb_module.c
@@ -1,7 +1,7 @@
 #include <ngx_lua_resty_lmdb_module.h>
 
 
-#define MAX_BUF_LEN         256
+#define MAX_BUF_LEN         512
 #define ENC_KEY_LEN         32
 
 #ifndef EVP_DIGEST_CONSTANT

--- a/src/ngx_lua_resty_lmdb_module.c
+++ b/src/ngx_lua_resty_lmdb_module.c
@@ -136,7 +136,7 @@ ngx_lua_resty_lmdb_init_conf(ngx_cycle_t *cycle, void *conf)
         ngx_strcasecmp(
             lcf->encryption_type.data, (u_char*)"chacha20-poly1305") != 0 ) {
 
-        ngx_log_error(NGX_LOG_EMERG, cycle->log, 0,
+        ngx_log_error(NGX_LOG_CRIT, cycle->log, 0,
                 "invalid \"lmdb_encryption_type\": \"%V\"",
                 &lcf->encryption_type);
 
@@ -145,7 +145,7 @@ ngx_lua_resty_lmdb_init_conf(ngx_cycle_t *cycle, void *conf)
 
     if (lcf->key_file.data != NULL) {
         if (ngx_conf_full_name(cycle, &lcf->key_file, 1) != NGX_OK) {
-            ngx_log_error(NGX_LOG_EMERG, cycle->log, 0,
+            ngx_log_error(NGX_LOG_CRIT, cycle->log, 0,
                           "search \"%V\" failed", &lcf->key_file);
             return NGX_CONF_ERROR;
         }
@@ -158,7 +158,7 @@ ngx_lua_resty_lmdb_init_conf(ngx_cycle_t *cycle, void *conf)
                                 NGX_FILE_OPEN, 0);
 
         if (file.fd == NGX_INVALID_FILE) {
-            ngx_log_error(NGX_LOG_EMERG, cycle->log, ngx_errno,
+            ngx_log_error(NGX_LOG_CRIT, cycle->log, ngx_errno,
                           ngx_open_file_n " \"%V\" failed", &file.name);
             return NGX_CONF_ERROR;
         }
@@ -174,7 +174,7 @@ ngx_lua_resty_lmdb_init_conf(ngx_cycle_t *cycle, void *conf)
 
         buf = ngx_pcalloc(cycle->pool, size);
         if (buf == NULL) {
-            ngx_log_error(NGX_LOG_EMERG, cycle->log, 0,
+            ngx_log_error(NGX_LOG_CRIT, cycle->log, 0,
                           "allocate key memory failed");
             return NGX_CONF_ERROR;
         }
@@ -206,7 +206,7 @@ ngx_lua_resty_lmdb_init_conf(ngx_cycle_t *cycle, void *conf)
         cipher = EVP_get_cipherbyname((char *)lcf->encryption_type.data);
 
         if (cipher == NULL ) {
-            ngx_log_error(NGX_LOG_EMERG, cycle->log, 0,
+            ngx_log_error(NGX_LOG_CRIT, cycle->log, 0,
                 "init \"lmdb_encryption\": \"%V\" failed",
                 &lcf->encryption_type);
 

--- a/src/ngx_lua_resty_lmdb_module.c
+++ b/src/ngx_lua_resty_lmdb_module.c
@@ -145,6 +145,8 @@ ngx_lua_resty_lmdb_init_conf(ngx_cycle_t *cycle, void *conf)
 
     if (lcf->key_file.data != NULL) {
         if (ngx_conf_full_name(cycle, &lcf->key_file, 1) != NGX_OK) {
+            ngx_log_error(NGX_LOG_EMERG, cycle->log, 0,
+                          "search \"%V\" failed", &lcf->key_file);
             return NGX_CONF_ERROR;
         }
 

--- a/src/ngx_lua_resty_lmdb_module.c
+++ b/src/ngx_lua_resty_lmdb_module.c
@@ -175,7 +175,8 @@ ngx_lua_resty_lmdb_init_conf(ngx_cycle_t *cycle, void *conf)
 
         if (size > MAX_BUF_LEN) {
             ngx_log_error(NGX_LOG_CRIT, cycle->log, 0,
-                          "\"%V\" must be less than 256 bytes", &file.name);
+                          "\"%V\" must be less than %d bytes",
+                          &file.name, MAX_BUF_LEN);
             ngx_close_file(file.fd);
             return NGX_CONF_ERROR;
         }

--- a/src/ngx_lua_resty_lmdb_module.c
+++ b/src/ngx_lua_resty_lmdb_module.c
@@ -185,6 +185,7 @@ ngx_lua_resty_lmdb_init_conf(ngx_cycle_t *cycle, void *conf)
         if (buf == NULL) {
             ngx_log_error(NGX_LOG_CRIT, cycle->log, 0,
                           "allocate key memory failed");
+            ngx_close_file(file.fd);
             return NGX_CONF_ERROR;
         }
 

--- a/src/ngx_lua_resty_lmdb_module.c
+++ b/src/ngx_lua_resty_lmdb_module.c
@@ -53,11 +53,11 @@ static ngx_command_t  ngx_lua_resty_lmdb_commands[] = {
       offsetof(ngx_lua_resty_lmdb_conf_t, key_file),
       NULL },
 
-    { ngx_string("lmdb_encryption_type"),
+    { ngx_string("lmdb_encryption_mode"),
       NGX_MAIN_CONF|NGX_DIRECT_CONF|NGX_CONF_TAKE1,
       ngx_conf_set_str_slot,
       0,
-      offsetof(ngx_lua_resty_lmdb_conf_t, encryption_type),
+      offsetof(ngx_lua_resty_lmdb_conf_t, encryption_mode),
       NULL },
 
       ngx_null_command
@@ -127,18 +127,18 @@ ngx_lua_resty_lmdb_init_conf(ngx_cycle_t *cycle, void *conf)
     ngx_conf_init_size_value(lcf->map_size, 1048576);
 
     /* The default encryption mode is aes-256-gcm */
-    if (lcf->encryption_type.data == NULL) {
-        ngx_str_set(&lcf->encryption_type, "aes-256-gcm");
+    if (lcf->encryption_mode.data == NULL) {
+        ngx_str_set(&lcf->encryption_mode, "aes-256-gcm");
     }
 
     if (ngx_strcasecmp(
-            lcf->encryption_type.data, (u_char*)"aes-256-gcm") != 0 &&
+            lcf->encryption_mode.data, (u_char*)"aes-256-gcm") != 0 &&
         ngx_strcasecmp(
-            lcf->encryption_type.data, (u_char*)"chacha20-poly1305") != 0 ) {
+            lcf->encryption_mode.data, (u_char*)"chacha20-poly1305") != 0 ) {
 
         ngx_log_error(NGX_LOG_CRIT, cycle->log, 0,
-                "invalid \"lmdb_encryption_type\": \"%V\"",
-                &lcf->encryption_type);
+                "invalid \"lmdb_encryption_mode\": \"%V\"",
+                &lcf->encryption_mode);
 
         return NGX_CONF_ERROR;
     }
@@ -203,12 +203,12 @@ ngx_lua_resty_lmdb_init_conf(ngx_cycle_t *cycle, void *conf)
     }
 
     if (lcf->key_data.data != NULL) {
-        cipher = EVP_get_cipherbyname((char *)lcf->encryption_type.data);
+        cipher = EVP_get_cipherbyname((char *)lcf->encryption_mode.data);
 
         if (cipher == NULL ) {
             ngx_log_error(NGX_LOG_CRIT, cycle->log, 0,
                 "init \"lmdb_encryption\": \"%V\" failed",
-                &lcf->encryption_type);
+                &lcf->encryption_mode);
 
             return NGX_CONF_ERROR;
         }
@@ -292,10 +292,10 @@ static ngx_int_t ngx_lua_resty_lmdb_init_worker(ngx_cycle_t *cycle)
 
         /* destroy data*/
         ngx_explicit_memzero(lcf->key_data.data, lcf->key_data.len);
-        ngx_explicit_memzero(lcf->encryption_type.data, lcf->encryption_type.len);
+        ngx_explicit_memzero(lcf->encryption_mode.data, lcf->encryption_mode.len);
 
         ngx_str_null(&lcf->key_data);
-        ngx_str_null(&lcf->encryption_type);
+        ngx_str_null(&lcf->encryption_mode);
     }
 
     rc = mdb_env_open(lcf->env, (const char *) lcf->env_path->name.data, 0, 0600);

--- a/src/ngx_lua_resty_lmdb_module.h
+++ b/src/ngx_lua_resty_lmdb_module.h
@@ -14,6 +14,7 @@ struct ngx_lua_resty_lmdb_conf_s {
     MDB_env     *env;
     MDB_txn     *ro_txn;
 
+    ngx_str_t    key_file;
     ngx_str_t    key_data;
     ngx_str_t    encryption_type;
 };

--- a/src/ngx_lua_resty_lmdb_module.h
+++ b/src/ngx_lua_resty_lmdb_module.h
@@ -16,7 +16,7 @@ struct ngx_lua_resty_lmdb_conf_s {
 
     ngx_str_t    key_file;
     ngx_str_t    key_data;
-    ngx_str_t    encryption_type;
+    ngx_str_t    encryption_mode;
 };
 
 

--- a/t/05-encrypt_and_find_plaintext.t
+++ b/t/05-encrypt_and_find_plaintext.t
@@ -12,7 +12,7 @@ my $pwd = cwd();
 our $MainConfig = qq{
     lmdb_environment_path /tmp/test5.mdb;
     lmdb_map_size 5m;
-    lmdb_encryption_key_data "123456789009876543211";
+    lmdb_encryption_key /etc/hostname;
     lmdb_encryption_type "chacha20-poly1305";
 };
 

--- a/t/05-encrypt_and_find_plaintext.t
+++ b/t/05-encrypt_and_find_plaintext.t
@@ -13,7 +13,7 @@ our $MainConfig = qq{
     lmdb_environment_path /tmp/test5.mdb;
     lmdb_map_size 5m;
     lmdb_encryption_key /etc/hostname;
-    lmdb_encryption_type "chacha20-poly1305";
+    lmdb_encryption_mode "chacha20-poly1305";
 };
 
 our $MainConfig1 = qq{

--- a/t/06-open_encrypted_db_with_wrong_key.t
+++ b/t/06-open_encrypted_db_with_wrong_key.t
@@ -13,14 +13,14 @@ our $MainConfig = qq{
     lmdb_environment_path /tmp/test7.mdb;
     lmdb_map_size 5m;
     lmdb_encryption_key /etc/hostname;
-    lmdb_encryption_type "AES-256-GCM";
+    lmdb_encryption_mode "AES-256-GCM";
 };
 
 our $MainConfig1 = qq{
     lmdb_environment_path /tmp/test7.mdb;
     lmdb_map_size 5m;
     lmdb_encryption_key /etc/hosts;
-    lmdb_encryption_type "AES-256-GCM";
+    lmdb_encryption_mode "AES-256-GCM";
 };
 
 our $HttpConfig = qq{

--- a/t/06-open_encrypted_db_with_wrong_key.t
+++ b/t/06-open_encrypted_db_with_wrong_key.t
@@ -12,14 +12,14 @@ my $pwd = cwd();
 our $MainConfig = qq{
     lmdb_environment_path /tmp/test7.mdb;
     lmdb_map_size 5m;
-    lmdb_encryption_key_data "12345678900987654321123456789002";
+    lmdb_encryption_key /etc/hostname;
     lmdb_encryption_type "AES-256-GCM";
 };
 
 our $MainConfig1 = qq{
     lmdb_environment_path /tmp/test7.mdb;
     lmdb_map_size 5m;
-    lmdb_encryption_key_data "1234567890098765432";
+    lmdb_encryption_key /etc/hosts;
     lmdb_encryption_type "AES-256-GCM";
 };
 


### PR DESCRIPTION
change `lmdb_encryption_key_data` to `lmdb_encryption_key`, 
which refers to a key file in the disk.

change `lmdb_encryption_type` to `lmdb_encryption_mode`.