### PR TITLE
chore(ci): optimize workflow triggers

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,13 @@
 name: Lint
 
-on: [push, pull_request]
+on:
+  pull_request: {}
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,13 @@
 name: Tests
 
-on: [push, pull_request]
+on:
+  pull_request: {}
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   tests:


### PR DESCRIPTION
Eliminate redundant/duplicate workflow runs by only running PR workflows for the `pull_request` trigger type, and `main` branch pushes. 