### PR TITLE
fix(status): redesign env info metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Get the LMDB database runtime information. `status` table struct as below.
     "allocated_pages": 2,
     "in_use_pages": 0,
     "entries": 0,
-    "map_size": 10485760
+    "map_size": 10485760 # in bytes
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Get the LMDB database runtime information. `status` table struct as below.
     "page_size": 4096,
     "max_readers":126,
     "num_readers": 1,
-    "alocated_pages": 2,
+    "allocated_pages": 2,
     "used_pages": 0,
     "entries": 0,
     "map_size": 10485760

--- a/README.md
+++ b/README.md
@@ -73,13 +73,13 @@ In case of error, `nil` and a string describing the error will be returned inste
 Get the LMDB database runtime information. `status` table struct as below.
 ```
 {
-  "last_used_page": 11,
-  "last_txnid": 14,
-  "max_readers": 126,
-  "num_readers": 1,
-  "map_size": 1048576,
-  "page_size": 4096,
-  "max_map_size": 1048576
+    "page_size": 4096,
+    "max_readers":126,
+    "num_readers": 1,
+    "alocated_pages": 2,
+    "used_pages": 0,
+    "entries": 0,
+    "map_size": 10485760
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Get the LMDB database runtime information. `status` table struct as below.
     "max_readers":126,
     "num_readers": 1,
     "allocated_pages": 2,
-    "used_pages": 0,
+    "in_use_pages": 0,
     "entries": 0,
     "map_size": 10485760
 }

--- a/lib/resty/lmdb/status.lua
+++ b/lib/resty/lmdb/status.lua
@@ -18,7 +18,7 @@ ffi.cdef([[
         unsigned int    max_readers;     /**< max reader slots in the environment */
         unsigned int    num_readers;     /**< max reader slots used in the environment */
         unsigned int    allocated_pages;  /**< number of pages allocated */
-        size_t          used_pages;      /**< number of pages used */
+        size_t          in_use_pages;      /**< number of pages used */
         unsigned int    entries;         /**< the number of entries (key/value pairs) in the environment */
     } ngx_lua_resty_lmdb_ffi_status_t;
 
@@ -41,7 +41,7 @@ function _M.get_env_info()
         max_readers    = tonumber(env_status[0].max_readers),
         num_readers    = tonumber(env_status[0].num_readers),
         allocated_pages = tonumber(env_status[0].allocated_pages),
-        used_pages     = tonumber(env_status[0].used_pages),
+        in_use_pages     = tonumber(env_status[0].in_use_pages),
         entries        = tonumber(env_status[0].entries),
     }
 end

--- a/lib/resty/lmdb/status.lua
+++ b/lib/resty/lmdb/status.lua
@@ -18,7 +18,7 @@ ffi.cdef([[
         unsigned int    max_readers;     /**< max reader slots in the environment */
         unsigned int    num_readers;     /**< max reader slots used in the environment */
         unsigned int    allocated_pages; /**< number of pages allocated */
-        size_t          in_use_pages;    /**< number of pages used */
+        size_t          in_use_pages;    /**< number of pages currently in-use */
         unsigned int    entries;         /**< the number of entries (key/value pairs) in the environment */
     } ngx_lua_resty_lmdb_ffi_status_t;
 

--- a/lib/resty/lmdb/status.lua
+++ b/lib/resty/lmdb/status.lua
@@ -15,11 +15,11 @@ ffi.cdef([[
     typedef struct {
         size_t          map_size;        /**< Size of the data memory map */
         unsigned int    page_size;       /**< Size of a database page. */
-        size_t          max_map_size;    /**< Size of the data memory map */
-        unsigned int    last_used_page;  /**< page numbers of the last used pages */
-        size_t          last_txnid;      /**< ID of the last committed transaction */
         unsigned int    max_readers;     /**< max reader slots in the environment */
         unsigned int    num_readers;     /**< max reader slots used in the environment */
+        unsigned int    alocated_pages;  /**< number of pages allocated */
+        unsigned int    used_pages;      /**< number of pages used */
+        unsigned int    entries;         /**< the number of entries (key/value pairs) in the environment */
     } ngx_lua_resty_lmdb_ffi_status_t;
 
     int ngx_lua_resty_lmdb_ffi_env_info(ngx_lua_resty_lmdb_ffi_status_t *lst, char **err);    
@@ -38,11 +38,11 @@ function _M.get_env_info()
     return {
         map_size       = tonumber(env_status[0].map_size),
         page_size      = tonumber(env_status[0].page_size),
-        max_map_size   = tonumber(env_status[0].max_map_size),
-        last_used_page = tonumber(env_status[0].last_used_page),
-        last_txnid     = tonumber(env_status[0].last_txnid),
         max_readers    = tonumber(env_status[0].max_readers),
         num_readers    = tonumber(env_status[0].num_readers),
+        alocated_pages = tonumber(env_status[0].alocated_pages),
+        used_pages     = tonumber(env_status[0].used_pages),
+        entries        = tonumber(env_status[0].entries),
     }
 end
 

--- a/lib/resty/lmdb/status.lua
+++ b/lib/resty/lmdb/status.lua
@@ -17,7 +17,7 @@ ffi.cdef([[
         unsigned int    page_size;       /**< Size of a database page. */
         unsigned int    max_readers;     /**< max reader slots in the environment */
         unsigned int    num_readers;     /**< max reader slots used in the environment */
-        unsigned int    alocated_pages;  /**< number of pages allocated */
+        unsigned int    allocated_pages;  /**< number of pages allocated */
         size_t          used_pages;      /**< number of pages used */
         unsigned int    entries;         /**< the number of entries (key/value pairs) in the environment */
     } ngx_lua_resty_lmdb_ffi_status_t;
@@ -40,7 +40,7 @@ function _M.get_env_info()
         page_size      = tonumber(env_status[0].page_size),
         max_readers    = tonumber(env_status[0].max_readers),
         num_readers    = tonumber(env_status[0].num_readers),
-        alocated_pages = tonumber(env_status[0].alocated_pages),
+        allocated_pages = tonumber(env_status[0].allocated_pages),
         used_pages     = tonumber(env_status[0].used_pages),
         entries        = tonumber(env_status[0].entries),
     }

--- a/lib/resty/lmdb/status.lua
+++ b/lib/resty/lmdb/status.lua
@@ -17,8 +17,8 @@ ffi.cdef([[
         unsigned int    page_size;       /**< Size of a database page. */
         unsigned int    max_readers;     /**< max reader slots in the environment */
         unsigned int    num_readers;     /**< max reader slots used in the environment */
-        unsigned int    allocated_pages;  /**< number of pages allocated */
-        size_t          in_use_pages;      /**< number of pages used */
+        unsigned int    allocated_pages; /**< number of pages allocated */
+        size_t          in_use_pages;    /**< number of pages used */
         unsigned int    entries;         /**< the number of entries (key/value pairs) in the environment */
     } ngx_lua_resty_lmdb_ffi_status_t;
 
@@ -36,13 +36,13 @@ function _M.get_env_info()
     assert(env_status[0] ~= nil)
 
     return {
-        map_size       = tonumber(env_status[0].map_size),
-        page_size      = tonumber(env_status[0].page_size),
-        max_readers    = tonumber(env_status[0].max_readers),
-        num_readers    = tonumber(env_status[0].num_readers),
+        map_size        = tonumber(env_status[0].map_size),
+        page_size       = tonumber(env_status[0].page_size),
+        max_readers     = tonumber(env_status[0].max_readers),
+        num_readers     = tonumber(env_status[0].num_readers),
         allocated_pages = tonumber(env_status[0].allocated_pages),
-        in_use_pages     = tonumber(env_status[0].in_use_pages),
-        entries        = tonumber(env_status[0].entries),
+        in_use_pages    = tonumber(env_status[0].in_use_pages),
+        entries         = tonumber(env_status[0].entries),
     }
 end
 

--- a/lib/resty/lmdb/status.lua
+++ b/lib/resty/lmdb/status.lua
@@ -18,7 +18,7 @@ ffi.cdef([[
         unsigned int    max_readers;     /**< max reader slots in the environment */
         unsigned int    num_readers;     /**< max reader slots used in the environment */
         unsigned int    alocated_pages;  /**< number of pages allocated */
-        unsigned int    used_pages;      /**< number of pages used */
+        size_t          used_pages;      /**< number of pages used */
         unsigned int    entries;         /**< the number of entries (key/value pairs) in the environment */
     } ngx_lua_resty_lmdb_ffi_status_t;
 

--- a/src/ngx_lua_resty_lmdb_module.c
+++ b/src/ngx_lua_resty_lmdb_module.c
@@ -710,8 +710,6 @@ int ngx_lua_resty_lmdb_ffi_env_info(ngx_lua_resty_lmdb_ffi_status_t *lst, const 
     lst->num_readers    = mei.me_numreaders;
     lst->used_pages     = mst.ms_branch_pages + mst.ms_leaf_pages
                           + mst.ms_overflow_pages;
-    ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0, "used_pages: %u ms_branch_pages: %u ms_leaf_pages: %u ms_overflow_pages: %u",
-        lst->used_pages, mst.ms_branch_pages, mst.ms_leaf_pages, mst.ms_overflow_pages);
     lst->alocated_pages = mei.me_last_pgno + 1;
     lst->entries        = mst.ms_entries;
 

--- a/src/ngx_lua_resty_lmdb_module.c
+++ b/src/ngx_lua_resty_lmdb_module.c
@@ -710,7 +710,7 @@ int ngx_lua_resty_lmdb_ffi_env_info(ngx_lua_resty_lmdb_ffi_status_t *lst, const 
     lst->num_readers    = mei.me_numreaders;
     lst->used_pages     = mst.ms_branch_pages + mst.ms_leaf_pages
                           + mst.ms_overflow_pages;
-    ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0, "used_pages: %Yu ms_branch_pages: %Yu ms_leaf_pages: %Yu ms_overflow_pages:%Yu",
+    ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0, "used_pages: %u ms_branch_pages: %u ms_leaf_pages: %u ms_overflow_pages: %u",
         lst->used_pages, mst.ms_branch_pages, mst.ms_leaf_pages, mst.ms_overflow_pages);
     lst->alocated_pages = mei.me_last_pgno + 1;
     lst->entries        = mst.ms_entries;

--- a/src/ngx_lua_resty_lmdb_module.c
+++ b/src/ngx_lua_resty_lmdb_module.c
@@ -708,7 +708,7 @@ int ngx_lua_resty_lmdb_ffi_env_info(ngx_lua_resty_lmdb_ffi_status_t *lst, const 
     lst->page_size      = mst.ms_psize;
     lst->max_readers    = mei.me_maxreaders;
     lst->num_readers    = mei.me_numreaders;
-    lst->used_pages     = mst.ms_branch_pages + mst.ms_leaf_pages
+    lst->in_use_pages     = mst.ms_branch_pages + mst.ms_leaf_pages
                           + mst.ms_overflow_pages;
     lst->allocated_pages = mei.me_last_pgno + 1;
     lst->entries        = mst.ms_entries;

--- a/src/ngx_lua_resty_lmdb_module.c
+++ b/src/ngx_lua_resty_lmdb_module.c
@@ -704,14 +704,14 @@ int ngx_lua_resty_lmdb_ffi_env_info(ngx_lua_resty_lmdb_ffi_status_t *lst, const 
         return NGX_ERROR;
     }
 
-    lst->map_size       = mei.me_mapsize;
-    lst->page_size      = mst.ms_psize;
-    lst->max_readers    = mei.me_maxreaders;
-    lst->num_readers    = mei.me_numreaders;
-    lst->in_use_pages     = mst.ms_branch_pages + mst.ms_leaf_pages
-                          + mst.ms_overflow_pages;
-    lst->allocated_pages = mei.me_last_pgno + 1;
-    lst->entries        = mst.ms_entries;
+    lst->map_size           = mei.me_mapsize;
+    lst->page_size          = mst.ms_psize;
+    lst->max_readers        = mei.me_maxreaders;
+    lst->num_readers        = mei.me_numreaders;
+    lst->in_use_pages       = mst.ms_branch_pages + mst.ms_leaf_pages
+                                + mst.ms_overflow_pages;
+    lst->allocated_pages    = mei.me_last_pgno + 1;
+    lst->entries            = mst.ms_entries;
 
     return NGX_OK;
 }

--- a/src/ngx_lua_resty_lmdb_module.c
+++ b/src/ngx_lua_resty_lmdb_module.c
@@ -706,11 +706,12 @@ int ngx_lua_resty_lmdb_ffi_env_info(ngx_lua_resty_lmdb_ffi_status_t *lst, const 
 
     lst->map_size       = mei.me_mapsize;
     lst->page_size      = mst.ms_psize;
-    lst->max_map_size   = mei.me_mapsize;
-    lst->last_used_page = mei.me_last_pgno + 1;
-    lst->last_txnid     = mei.me_last_txnid;
     lst->max_readers    = mei.me_maxreaders;
     lst->num_readers    = mei.me_numreaders;
+    lst->used_pages     = mst.ms_branch_pages + mst.ms_leaf_pages
+                          + mst.ms_overflow_pages;
+    lst->alocated_pages = mei.me_last_pgno + 1;
+    lst->entries        = mst.ms_entries;
 
     return NGX_OK;
 }

--- a/src/ngx_lua_resty_lmdb_module.c
+++ b/src/ngx_lua_resty_lmdb_module.c
@@ -710,7 +710,7 @@ int ngx_lua_resty_lmdb_ffi_env_info(ngx_lua_resty_lmdb_ffi_status_t *lst, const 
     lst->num_readers    = mei.me_numreaders;
     lst->used_pages     = mst.ms_branch_pages + mst.ms_leaf_pages
                           + mst.ms_overflow_pages;
-    lst->alocated_pages = mei.me_last_pgno + 1;
+    lst->allocated_pages = mei.me_last_pgno + 1;
     lst->entries        = mst.ms_entries;
 
     return NGX_OK;

--- a/src/ngx_lua_resty_lmdb_module.c
+++ b/src/ngx_lua_resty_lmdb_module.c
@@ -710,6 +710,8 @@ int ngx_lua_resty_lmdb_ffi_env_info(ngx_lua_resty_lmdb_ffi_status_t *lst, const 
     lst->num_readers    = mei.me_numreaders;
     lst->used_pages     = mst.ms_branch_pages + mst.ms_leaf_pages
                           + mst.ms_overflow_pages;
+    ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0, "used_pages: %Yu ms_branch_pages: %Yu ms_leaf_pages: %Yu ms_overflow_pages:%Yu",
+        lst->used_pages, mst.ms_branch_pages, mst.ms_leaf_pages, mst.ms_overflow_pages);
     lst->alocated_pages = mei.me_last_pgno + 1;
     lst->entries        = mst.ms_entries;
 

--- a/src/ngx_lua_resty_lmdb_module.h
+++ b/src/ngx_lua_resty_lmdb_module.h
@@ -47,7 +47,7 @@ typedef struct {
     unsigned int    max_readers;     /**< max reader slots in the environment */
     unsigned int    num_readers;     /**< max reader slots used in the environment */
     unsigned int    allocated_pages;  /**< number of pages allocated */
-    size_t          used_pages;      /**< number of pages used */
+    size_t          in_use_pages;      /**< number of pages used */
     unsigned int    entries;         /**< the number of entries (key/value pairs) in the environment */
 } ngx_lua_resty_lmdb_ffi_status_t;
 

--- a/src/ngx_lua_resty_lmdb_module.h
+++ b/src/ngx_lua_resty_lmdb_module.h
@@ -44,11 +44,11 @@ struct ngx_lua_resty_lmdb_operation_s {
 typedef struct {
     size_t          map_size;        /**< Size of the data memory map */
     unsigned int    page_size;       /**< Size of a database page. */
-    size_t          max_map_size;    /**< Size of the data memory map */
-    unsigned int    last_used_page;  /**< page numbers of the last used pages */
-    size_t          last_txnid;      /**< ID of the last committed transaction */
     unsigned int    max_readers;     /**< max reader slots in the environment */
     unsigned int    num_readers;     /**< max reader slots used in the environment */
+    unsigned int    alocated_pages;  /**< number of pages allocated */
+    unsigned int    used_pages;      /**< number of pages used */
+    unsigned int    entries;         /**< the number of entries (key/value pairs) in the environment */
 } ngx_lua_resty_lmdb_ffi_status_t;
 
 typedef struct ngx_lua_resty_lmdb_operation_s ngx_lua_resty_lmdb_operation_t;

--- a/src/ngx_lua_resty_lmdb_module.h
+++ b/src/ngx_lua_resty_lmdb_module.h
@@ -47,7 +47,7 @@ typedef struct {
     unsigned int    max_readers;     /**< max reader slots in the environment */
     unsigned int    num_readers;     /**< max reader slots used in the environment */
     unsigned int    alocated_pages;  /**< number of pages allocated */
-    unsigned int    used_pages;      /**< number of pages used */
+    size_t          used_pages;      /**< number of pages used */
     unsigned int    entries;         /**< the number of entries (key/value pairs) in the environment */
 } ngx_lua_resty_lmdb_ffi_status_t;
 

--- a/src/ngx_lua_resty_lmdb_module.h
+++ b/src/ngx_lua_resty_lmdb_module.h
@@ -46,7 +46,7 @@ typedef struct {
     unsigned int    page_size;       /**< Size of a database page. */
     unsigned int    max_readers;     /**< max reader slots in the environment */
     unsigned int    num_readers;     /**< max reader slots used in the environment */
-    unsigned int    alocated_pages;  /**< number of pages allocated */
+    unsigned int    allocated_pages;  /**< number of pages allocated */
     size_t          used_pages;      /**< number of pages used */
     unsigned int    entries;         /**< the number of entries (key/value pairs) in the environment */
 } ngx_lua_resty_lmdb_ffi_status_t;

--- a/src/ngx_lua_resty_lmdb_module.h
+++ b/src/ngx_lua_resty_lmdb_module.h
@@ -46,8 +46,8 @@ typedef struct {
     unsigned int    page_size;       /**< Size of a database page. */
     unsigned int    max_readers;     /**< max reader slots in the environment */
     unsigned int    num_readers;     /**< max reader slots used in the environment */
-    unsigned int    allocated_pages;  /**< number of pages allocated */
-    size_t          in_use_pages;      /**< number of pages used */
+    unsigned int    allocated_pages; /**< number of pages allocated */
+    size_t          in_use_pages;    /**< number of pages used */
     unsigned int    entries;         /**< the number of entries (key/value pairs) in the environment */
 } ngx_lua_resty_lmdb_ffi_status_t;
 

--- a/t/07-status.t
+++ b/t/07-status.t
@@ -45,7 +45,7 @@ __DATA__
             ngx.say(info["max_readers"])
             ngx.say(info["num_readers"])
             ngx.say(info["allocated_pages"])
-            ngx.say(info["used_pages"])
+            ngx.say(info["in_use_pages"])
             ngx.say(info["entries"])
         }
     }
@@ -102,7 +102,7 @@ GET /t
             ngx.say(info["map_size"])
             ngx.say(info["page_size"])
 
-            local old_used_pages = info["used_pages"]
+            local old_in_use_pages = info["in_use_pages"]
             local a = string.rep("Abcdef", 5000)
             ngx.say(l.set("test", a))
             ngx.say(l.get("test_not_exist"))
@@ -111,8 +111,8 @@ GET /t
             ngx.say(info["map_size"])
             ngx.say(info["page_size"])
 
-            local used_pages =  info["used_pages"]
-            ngx.say(used_pages > old_used_pages)
+            local in_use_pages =  info["in_use_pages"]
+            ngx.say(in_use_pages > old_in_use_pages)
         }
     }
 --- request
@@ -148,7 +148,7 @@ true
             local info = l.get_env_info()
             ngx.say(info["map_size"])
             ngx.say(info["page_size"])
-            local old_used_pages = info["used_pages"]
+            local old_in_use_pages = info["in_use_pages"]
             local old_allocated_pages = info["allocated_pages"]
             ngx.say("old_entries: ", info["entries"])
             local t = txn.begin()
@@ -172,9 +172,9 @@ true
             ngx.say(info["map_size"])
             ngx.say(info["page_size"])
                         ngx.say("entries: ", info["entries"])
-            local used_pages =  info["used_pages"]
+            local in_use_pages =  info["in_use_pages"]
             local allocated_pages = info["allocated_pages"]
-            ngx.say(used_pages > old_used_pages)
+            ngx.say(in_use_pages > old_in_use_pages)
             ngx.say(allocated_pages > old_allocated_pages)
         }
     }

--- a/t/07-status.t
+++ b/t/07-status.t
@@ -140,7 +140,6 @@ true
         content_by_lua_block {
             local txn = require("resty.lmdb.transaction")
             local l = require("resty.lmdb")
-            local cjson = require("cjson")
 
             l.set("testbalabala", "aaaa")
             ngx.say(l.db_drop(false))
@@ -150,7 +149,6 @@ true
             ngx.say(info["page_size"])
             local old_in_use_pages = info["in_use_pages"]
             local old_allocated_pages = info["allocated_pages"]
-            ngx.say("old_entries: ", info["entries"])
             local t = txn.begin()
             t:get("not_found")
             t:set("test", "value")
@@ -171,7 +169,6 @@ true
             local info = l.get_env_info()
             ngx.say(info["map_size"])
             ngx.say(info["page_size"])
-                        ngx.say("entries: ", info["entries"])
             local in_use_pages =  info["in_use_pages"]
             local allocated_pages = info["allocated_pages"]
             ngx.say(in_use_pages >= old_in_use_pages)

--- a/t/07-status.t
+++ b/t/07-status.t
@@ -112,7 +112,7 @@ GET /t
             ngx.say(info["page_size"])
 
             local in_use_pages =  info["in_use_pages"]
-            ngx.say(in_use_pages > old_in_use_pages)
+            ngx.say(in_use_pages >= old_in_use_pages)
         }
     }
 --- request
@@ -174,8 +174,8 @@ true
                         ngx.say("entries: ", info["entries"])
             local in_use_pages =  info["in_use_pages"]
             local allocated_pages = info["allocated_pages"]
-            ngx.say(in_use_pages > old_in_use_pages)
-            ngx.say(allocated_pages > old_allocated_pages)
+            ngx.say(in_use_pages >= old_in_use_pages)
+            ngx.say(allocated_pages >= old_allocated_pages)
         }
     }
 --- request

--- a/t/07-status.t
+++ b/t/07-status.t
@@ -76,6 +76,8 @@ GET /t
             local info = l.get_env_info()
             ngx.say(info["map_size"])
             ngx.say(info["page_size"])
+            local cjson = require("cjson")
+            ngx.say(cjson.encode(info))
         }
     }
 --- request

--- a/t/07-status.t
+++ b/t/07-status.t
@@ -44,7 +44,7 @@ __DATA__
             ngx.say(info["page_size"])
             ngx.say(info["max_readers"])
             ngx.say(info["num_readers"])
-            ngx.say(info["alocated_pages"])
+            ngx.say(info["allocated_pages"])
             ngx.say(info["used_pages"])
             ngx.say(info["entries"])
         }
@@ -112,8 +112,7 @@ GET /t
             ngx.say(info["page_size"])
 
             local used_pages =  info["used_pages"]
-                        local cjson = require("cjson")
-            ngx.say(used_pages >= old_used_pages)
+            ngx.say(used_pages > old_used_pages)
         }
     }
 --- request
@@ -141,6 +140,7 @@ true
         content_by_lua_block {
             local txn = require("resty.lmdb.transaction")
             local l = require("resty.lmdb")
+            local cjson = require("cjson")
 
             l.set("testbalabala", "aaaa")
             ngx.say(l.db_drop(false))
@@ -149,7 +149,8 @@ true
             ngx.say(info["map_size"])
             ngx.say(info["page_size"])
             local old_used_pages = info["used_pages"]
-            local old_alocated_pages = info["alocated_pages"]
+            local old_allocated_pages = info["allocated_pages"]
+            ngx.say("old_entries: ", info["entries"])
             local t = txn.begin()
             t:get("not_found")
             t:set("test", "value")
@@ -170,10 +171,11 @@ true
             local info = l.get_env_info()
             ngx.say(info["map_size"])
             ngx.say(info["page_size"])
+                        ngx.say("entries: ", info["entries"])
             local used_pages =  info["used_pages"]
-            local alocated_pages = info["alocated_pages"]
-            ngx.say(used_pages >= old_used_pages)
-            ngx.say(alocated_pages >= old_alocated_pages)
+            local allocated_pages = info["allocated_pages"]
+            ngx.say(used_pages > old_used_pages)
+            ngx.say(allocated_pages > old_allocated_pages)
         }
     }
 --- request


### PR DESCRIPTION
change lmdb info table entry to `used_pages` `alocated_pages` `entries`
```
    lst->used_pages     = mst.ms_branch_pages + mst.ms_leaf_pages
                          + mst.ms_overflow_pages;
    lst->alocated_pages = mei.me_last_pgno + 1;
    lst->entries        = mst.ms_entries;
```


FTI-5111