### PR TITLE
perf(lib): add internal tablepool for transaction

### DIFF
--- a/lib/resty/lmdb/tpool.lua
+++ b/lib/resty/lmdb/tpool.lua
@@ -1,0 +1,63 @@
+local newtab   = require("table.new")
+local cleartab = require("table.clear")
+
+
+local _M = {}
+
+
+local pool = {
+    c = 0,
+    [0] = 0,
+    }
+
+
+local MAX_POOL_SIZE     = 10 * 1000    -- 10K
+local MAX_RELEASE_COUNT = MAX_POOL_SIZE * 100
+
+
+function _M.fetch(narr, nrec)
+    local len = pool[0]
+
+    if len > 0 then
+        local obj = pool[len]
+        pool[len] = nil
+        pool[0] = len - 1
+        return obj
+    end
+
+    return newtab(narr, nrec)
+end
+
+
+function _M.release(obj)
+    if not obj then
+        error("object empty", 2)
+    end
+
+    cleartab(obj)
+
+    do
+        local cnt = pool.c + 1
+        if cnt >= MAX_RELEASE_COUNT then
+            pool = {
+                c = 0,
+                [0] = 0,
+            }
+            return
+        end
+        pool.c = cnt
+    end
+
+    local len = pool[0] + 1
+
+    if len > MAX_POOL_SIZE then
+        -- discard it simply
+        return
+    end
+
+    pool[len] = obj
+    pool[0] = len
+end
+
+
+return _M

--- a/lib/resty/lmdb/tpool.lua
+++ b/lib/resty/lmdb/tpool.lua
@@ -31,7 +31,7 @@ end
 
 function _M.release(obj)
     if not obj then
-        error("object empty", 2)
+        return
     end
 
     cleartab(obj)


### PR DESCRIPTION
This PR is a mimic of https://github.com/openresty/lua-tablepool,
but the capacity of the pool increase to 10k to fit the scene of resty-lmdb.

The goal is to reuse small op tables in transaction as many as we can.