### PR TITLE
fix(transaction): fix used after free when committing a transaction

### DIFF
--- a/lib/resty/lmdb/transaction.lua
+++ b/lib/resty/lmdb/transaction.lua
@@ -265,8 +265,9 @@ function _TXN_MT:commit()
     end
 
 ::again::
+    local buf = get_string_buf(value_buf_size, false)
     local ret = C.ngx_lua_resty_lmdb_ffi_execute(ops, self.n, self.write,
-                    get_string_buf(value_buf_size, false), value_buf_size, err_ptr)
+                    buf, value_buf_size, err_ptr)
     if ret == NGX_ERROR then
         return nil, ffi_string(err_ptr[0])
     end


### PR DESCRIPTION
```lua
local ret = C.ngx_lua_resty_lmdb_ffi_execute(ops, self.n, self.write,
                    get_string_buf(value_buf_size, false), value_buf_size, err_ptr)
```

The buffer returned by `get_string_buf(value_buf_size, false)` has no reference in this function, so it might be released after the FFI call.

This buffer is used for saving the values of keys, so this is used after free.

[KAG-1986]

[KAG-1986]: https://konghq.atlassian.net/browse/KAG-1986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ