### PR TITLE
fix(src): validation log with notice level

### DIFF
--- a/src/ngx_lua_resty_lmdb_module.c
+++ b/src/ngx_lua_resty_lmdb_module.c
@@ -545,7 +545,7 @@ static ngx_int_t ngx_lua_resty_lmdb_init(ngx_cycle_t *cycle)
     if (rc != NGX_OK) {
         ngx_lua_resty_lmdb_close_file(cycle, lcf);
 
-        ngx_log_error(rc == NGX_DECLINED ? NGX_LOG_NOTICE : NGX_LOG_WARN,
+        ngx_log_error((rc == NGX_DECLINED ? NGX_LOG_NOTICE : NGX_LOG_WARN),
                       cycle->log, 0,
                       "LMDB validation tag mismatch, wiping the database");
 

--- a/src/ngx_lua_resty_lmdb_module.c
+++ b/src/ngx_lua_resty_lmdb_module.c
@@ -428,13 +428,13 @@ ngx_lua_resty_lmdb_validate(ngx_cycle_t *cycle,
             return NGX_OK;
         }
 
-        ngx_log_error(NGX_LOG_WARN, cycle->log, 0,
+        ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0,
                       "LMDB validation tag \"%*s\" did not match configured tag \"%V\"",
                       value.mv_size, value.mv_data,
                       &lcf->validation_tag);
 
     } else if (rc == MDB_NOTFOUND) {
-        ngx_log_error(NGX_LOG_WARN, cycle->log, 0,
+        ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0,
                       "LMDB validation tag does not exist");
 
     } else {
@@ -539,7 +539,7 @@ static ngx_int_t ngx_lua_resty_lmdb_init(ngx_cycle_t *cycle)
     if (ngx_lua_resty_lmdb_validate(cycle, lcf) != NGX_OK) {
         ngx_lua_resty_lmdb_close_file(cycle, lcf);
 
-        ngx_log_error(NGX_LOG_WARN, cycle->log, 0,
+        ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0,
                       "LMDB validation tag mismatch, wiping the database");
 
         /* remove lmdb files to clean data */

--- a/src/ngx_lua_resty_lmdb_module.c
+++ b/src/ngx_lua_resty_lmdb_module.c
@@ -435,7 +435,7 @@ ngx_lua_resty_lmdb_validate(ngx_cycle_t *cycle,
 
     } else if (rc == MDB_NOTFOUND) {
         ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0,
-                      "LMDB validation tag does not exist");
+                      "LMDB validation tag does not exist, assuming empty database");
 
         mdb_txn_abort(txn);
         return NGX_DECLINED;

--- a/src/ngx_lua_resty_lmdb_module.c
+++ b/src/ngx_lua_resty_lmdb_module.c
@@ -428,7 +428,7 @@ ngx_lua_resty_lmdb_validate(ngx_cycle_t *cycle,
             return NGX_OK;
         }
 
-        ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0,
+        ngx_log_error(NGX_LOG_WARN, cycle->log, 0,
                       "LMDB validation tag \"%*s\" did not match configured tag \"%V\"",
                       value.mv_size, value.mv_data,
                       &lcf->validation_tag);

--- a/src/ngx_lua_resty_lmdb_module.c
+++ b/src/ngx_lua_resty_lmdb_module.c
@@ -433,9 +433,15 @@ ngx_lua_resty_lmdb_validate(ngx_cycle_t *cycle,
                       value.mv_size, value.mv_data,
                       &lcf->validation_tag);
 
+        ngx_log_error(NGX_LOG_WARN, cycle->log, 0,
+                      "LMDB validation tag mismatch, wiping the database");
+
     } else if (rc == MDB_NOTFOUND) {
         ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0,
                       "LMDB validation tag does not exist");
+
+        ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0,
+                      "LMDB validation tag mismatch, wiping the database");
 
     } else {
         ngx_log_error(NGX_LOG_ERR, cycle->log, 0,
@@ -538,9 +544,6 @@ static ngx_int_t ngx_lua_resty_lmdb_init(ngx_cycle_t *cycle)
 
     if (ngx_lua_resty_lmdb_validate(cycle, lcf) != NGX_OK) {
         ngx_lua_resty_lmdb_close_file(cycle, lcf);
-
-        ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0,
-                      "LMDB validation tag mismatch, wiping the database");
 
         /* remove lmdb files to clean data */
         if (ngx_lua_resty_lmdb_remove_files(cycle, lcf) != NGX_OK) {

--- a/src/ngx_lua_resty_lmdb_module.c
+++ b/src/ngx_lua_resty_lmdb_module.c
@@ -540,7 +540,7 @@ static ngx_int_t ngx_lua_resty_lmdb_init(ngx_cycle_t *cycle)
 
     /* check lmdb validation tag */
 
-    rc = ngx_lua_resty_lmdb_validate(cycle, lcf)
+    rc = ngx_lua_resty_lmdb_validate(cycle, lcf);
 
     if (rc != NGX_OK) {
         ngx_lua_resty_lmdb_close_file(cycle, lcf);

--- a/src/ngx_lua_resty_lmdb_module.c
+++ b/src/ngx_lua_resty_lmdb_module.c
@@ -433,15 +433,12 @@ ngx_lua_resty_lmdb_validate(ngx_cycle_t *cycle,
                       value.mv_size, value.mv_data,
                       &lcf->validation_tag);
 
-        ngx_log_error(NGX_LOG_WARN, cycle->log, 0,
-                      "LMDB validation tag mismatch, wiping the database");
-
     } else if (rc == MDB_NOTFOUND) {
         ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0,
                       "LMDB validation tag does not exist");
 
-        ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0,
-                      "LMDB validation tag mismatch, wiping the database");
+        mdb_txn_abort(txn);
+        return NGX_DECLINED;
 
     } else {
         ngx_log_error(NGX_LOG_ERR, cycle->log, 0,
@@ -525,6 +522,7 @@ failed:
 
 static ngx_int_t ngx_lua_resty_lmdb_init(ngx_cycle_t *cycle)
 {
+    ngx_int_t                  rc;
     ngx_lua_resty_lmdb_conf_t *lcf;
 
     lcf = (ngx_lua_resty_lmdb_conf_t *) ngx_get_conf(cycle->conf_ctx,
@@ -542,8 +540,14 @@ static ngx_int_t ngx_lua_resty_lmdb_init(ngx_cycle_t *cycle)
 
     /* check lmdb validation tag */
 
-    if (ngx_lua_resty_lmdb_validate(cycle, lcf) != NGX_OK) {
+    rc = ngx_lua_resty_lmdb_validate(cycle, lcf)
+
+    if (rc != NGX_OK) {
         ngx_lua_resty_lmdb_close_file(cycle, lcf);
+
+        ngx_log_error(rc == NGX_DECLINED ? NGX_LOG_NOTICE : NGX_LOG_WARN,
+                      cycle->log, 0,
+                      "LMDB validation tag mismatch, wiping the database");
 
         /* remove lmdb files to clean data */
         if (ngx_lua_resty_lmdb_remove_files(cycle, lcf) != NGX_OK) {

--- a/t/11-validation-tag-plain.t
+++ b/t/11-validation-tag-plain.t
@@ -132,6 +132,6 @@ LMDB validation tag "3.3" did not match configured tag "3.4"
 LMDB validation tag mismatch, wiping the database
 set LMDB validation tag: "3.4"
 --- no_error_log
-[warn]
+[emerg]
 [error]
 [crit]

--- a/t/11-validation-tag-plain.t
+++ b/t/11-validation-tag-plain.t
@@ -99,7 +99,7 @@ LMDB validation tag does not exist
 LMDB validation tag mismatch, wiping the database
 set LMDB validation tag: "3.3"
 --- no_error_log
-[emerg]
+[warn]
 [error]
 [crit]
 
@@ -132,6 +132,6 @@ LMDB validation tag "3.3" did not match configured tag "3.4"
 LMDB validation tag mismatch, wiping the database
 set LMDB validation tag: "3.4"
 --- no_error_log
-[emerg]
+[warn]
 [error]
 [crit]


### PR DESCRIPTION
#34 introduced a new directive `lmdb_validation_tag`, but the mismatch log level `WARN` is too high,
this PR change the log level to `NOTICE`.

This may fix the ci test: https://github.com/Kong/kong/actions/runs/6876582885/job/18702488766

Related PR: https://github.com/Kong/kong/pull/12026