### PR TITLE
feat(page): add `page_size` parameter to allow overriding page size from

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ from the `txn` table when `commit()` returned an error is undefined.
 
 #### page
 
-**syntax:** *res, err = prefix.page(start, prefix, db?)*
+**syntax:** *res, err_or_more = prefix.page(start, prefix, db?, page_size?)*
 
 **context:** *any context*
 
@@ -238,6 +238,11 @@ The return value of this function is a table `res` where `res[1].key` and `res[1
 corresponds to the first key and value, `res[2].key` and `res[2].value` corresponds to the
 second and etc. If no keys matched the provided criteria, then an empty table will be
 returned.
+
+In case of success, the second return value will be a boolean indicating if more keys are
+possibly present. However, even when this value is `true`, it is possible subsequent `page`
+might return an empty list. If this value is `false`, then it is guaranteed no more keys
+matching the `prefix` is available.
 
 In case of errors, `nil` and an string describing the reason of the failure will be returned.
 

--- a/README.md
+++ b/README.md
@@ -234,6 +234,9 @@ from the `txn` table when `commit()` returned an error is undefined.
 Return all keys `>= start` and starts with `prefix`. If `db` is omitted,
 it defaults to `"_default"`.
 
+If `page_size` is specified, up to `page_size` results will be returned. However,
+`page_size` can not be set to less than `2` due to internal implementation limitations.
+
 The return value of this function is a table `res` where `res[1].key` and `res[1].value`
 corresponds to the first key and value, `res[2].key` and `res[2].value` corresponds to the
 second and etc. If no keys matched the provided criteria, then an empty table will be
@@ -245,6 +248,9 @@ might return an empty list. If this value is `false`, then it is guaranteed no m
 matching the `prefix` is available.
 
 In case of errors, `nil` and an string describing the reason of the failure will be returned.
+
+This is a low level function, most of the use case should instead use the higher level
+[lmdb.prefix](#prefix) iterator instead.
 
 [Back to TOC](#table-of-contents)
 

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ matching the `prefix` is available.
 
 In case of errors, `nil` and an string describing the reason of the failure will be returned.
 
-This is a low level function, most of the use case should instead use the higher level
+This is a low level function, most of the use case should use the higher level
 [lmdb.prefix](#prefix) iterator instead.
 
 [Back to TOC](#table-of-contents)

--- a/lib/resty/lmdb/prefix.lua
+++ b/lib/resty/lmdb/prefix.lua
@@ -26,9 +26,13 @@ local get_string_buf_size = base.get_string_buf_size
 local assert = assert
 
 
-function _M.page(start, prefix, db)
+function _M.page(start, prefix, db, page_size)
+    if not page_size then
+        page_size = DEFAULT_OPS_SIZE
+    end
+
     local value_buf_size = get_string_buf_size()
-    local ops = ffi_new("ngx_lua_resty_lmdb_operation_t[?]", DEFAULT_OPS_SIZE)
+    local ops = ffi_new("ngx_lua_resty_lmdb_operation_t[?]", page_size)
 
     ops[0].opcode = C.NGX_LMDB_OP_PREFIX
     ops[0].key.data = start
@@ -50,7 +54,7 @@ function _M.page(start, prefix, db)
 
 ::again::
     local buf = get_string_buf(value_buf_size, false)
-    local ret = C.ngx_lua_resty_lmdb_ffi_prefix(ops, DEFAULT_OPS_SIZE,
+    local ret = C.ngx_lua_resty_lmdb_ffi_prefix(ops, page_size,
                     buf, value_buf_size, err_ptr)
     if ret == NGX_ERROR then
         return nil, ffi_string(err_ptr[0])
@@ -83,8 +87,8 @@ function _M.page(start, prefix, db)
         res[i] = pair
     end
 
-    -- if ret == DEFAULT_OPS_SIZE, then it is possible there are more keys
-    return res, ret == DEFAULT_OPS_SIZE
+    -- if ret == page_size, then it is possible there are more keys
+    return res, ret == page_size
 end
 
 

--- a/lib/resty/lmdb/prefix.lua
+++ b/lib/resty/lmdb/prefix.lua
@@ -31,6 +31,8 @@ function _M.page(start, prefix, db, page_size)
         page_size = DEFAULT_OPS_SIZE
     end
 
+    assert(page_size >= 2, "'page_size' can not be less than 2")
+
     local value_buf_size = get_string_buf_size()
     local ops = ffi_new("ngx_lua_resty_lmdb_operation_t[?]", page_size)
 


### PR DESCRIPTION
caller side

This is useful for DB-less reads as DB-less defines it's own page size which might differ from what this library provides

[KAG-5342]

[KAG-5342]: https://konghq.atlassian.net/browse/KAG-5342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ