### PR TITLE
fix(prefix): fix bug when buffer realloc occurs during prefix lookup

### DIFF
--- a/lib/resty/lmdb/prefix.lua
+++ b/lib/resty/lmdb/prefix.lua
@@ -36,14 +36,6 @@ function _M.page(start, prefix, db, page_size)
     local value_buf_size = get_string_buf_size()
     local ops = ffi_new("ngx_lua_resty_lmdb_operation_t[?]", page_size)
 
-    ops[0].opcode = C.NGX_LMDB_OP_PREFIX
-    ops[0].key.data = start
-    ops[0].key.len = #start
-
-    ops[1].opcode = C.NGX_LMDB_OP_PREFIX
-    ops[1].key.data = prefix
-    ops[1].key.len = #prefix
-
     local dbi, err = get_dbi(false, db or DEFAULT_DB)
     if err then
         return nil, "unable to open DB for access: " .. err
@@ -55,6 +47,14 @@ function _M.page(start, prefix, db, page_size)
     ops[0].dbi = dbi
 
 ::again::
+    ops[0].opcode = C.NGX_LMDB_OP_PREFIX
+    ops[0].key.data = start
+    ops[0].key.len = #start
+
+    ops[1].opcode = C.NGX_LMDB_OP_PREFIX
+    ops[1].key.data = prefix
+    ops[1].key.len = #prefix
+
     local buf = get_string_buf(value_buf_size, false)
     local ret = C.ngx_lua_resty_lmdb_ffi_prefix(ops, page_size,
                     buf, value_buf_size, err_ptr)

--- a/src/ngx_lua_resty_lmdb_transaction.c
+++ b/src/ngx_lua_resty_lmdb_transaction.c
@@ -148,7 +148,8 @@ int ngx_lua_resty_lmdb_ffi_execute(ngx_lua_resty_lmdb_operation_t *ops,
         rc = mdb_txn_commit(txn);
         if (rc != 0) {
             *err = mdb_strerror(rc);
-            goto err;
+
+            return NGX_ERROR;
         }
 
     } else {


### PR DESCRIPTION
Prefix based lookup may need to reallocate the key/value buffer when the buffer size exceeds the default (currently 1MB).

However, because we use the `ops[0]` and `ops[1]` passed in is used for both providing the `after` and `prefix`, in case of `NGX_AGAIN`, these will be overwritten by the `ngx_lua_resty_lmdb_ffi_prefix()` function to the first and second key respectively, which breaks the retry and causing the second call to `ngx_lua_resty_lmdb_ffi_prefix()` to return empty.

This commit fixes the above issue by always resetting `ops[0]` and `ops[1]` between retries, therefore the above issue no longer occurs.

Also, this commit fixes a use-after-free bug for `db_drop()` operation when map is full.

[KAG-5874]

[KAG-5874]: https://konghq.atlassian.net/browse/KAG-5874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ