### PR TITLE
chore(deps): change lmdb submodule to github mirror

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   tests:
     name: Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,9 @@
 [submodule "lmdb"]
-	path = lmdb
-	url = https://git.openldap.org/openldap/openldap.git
-        branch = LMDB_0.9.33
+  path = lmdb
+  url = https://github.com/LMDB/lmdb
+  # This worked on the previous repo, https://git.openldap.org/openldap/openldap :
+  # branch = LMDB_0.9.33
+  # The new repo, https://github.com/LMDB/lmdb, is a mirror with the same commits, but not the same branches
+  # The 9.33 release is still at the same commit (3a29a24777c82a0165de813ae696a5068b5add30)
+  # See https://github.com/LMDB/lmdb/commit/3a29a24777c82a0165de813ae696a5068b5add30
+


### PR DESCRIPTION
https://git.openldap.org/openldap/openldap.git seems currently (9th July 2025) down. The github mirror seems up. This changes the repo and nothing else (well I had to bump the version of the ubuntu runner too)