### PR TITLE
chore(deps): bump lmdb to 1.0.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "lmdb"]
   path = lmdb
   url = https://github.com/openldap/openldap.git
-  branch = LMDB_0.9.35
+  branch = LMDB_1.0.1
   # This used to work, but has been offline since:
   # url = https://git.openldap.org/openldap/openldap
-  # branch = LMDB_0.9.35
+  # branch = LMDB_1.0.1

--- a/t/10-prefix.t
+++ b/t/10-prefix.t
@@ -400,12 +400,16 @@ PAGE SIZE 0
 
             local inserted = { test = "value" }
 
+            -- batch all inserts in one transaction to avoid per-write overhead
+            -- string.rep with 120 makes sure each page goes just over the 1MB
+            -- default buffer size and triggers a realloc
+            local txn = require("resty.lmdb.transaction")
+            local batch = txn.begin(2048)
             for i = 1, 2048 do
-                -- string.rep with 120 makes sure each page goes just over the 1MB
-                -- default buffer size and triggers a realloc
-                assert(l.set(string.rep("test", 120) .. i, string.rep("value", 120)))
+                batch:set(string.rep("test", 120) .. i, string.rep("value", 120))
                 inserted[string.rep("test", 120) .. i] = string.rep("value", 120)
             end
+            assert(batch:commit())
 
             ngx.say(l.set("u", "value4"))
             ngx.say(l.set("u1", "value5"))


### PR DESCRIPTION
Just a bump to LMDB library.

Notes:

The on-disk file format has changed in LMDB 1.0 and versions 0.9 and 1.0 are mutually incompatible. You must use v0.9 #mdb_dump to export your old DBs, and import with v1.0 #mdb_load if you want to migrate your existing data to use LMDB 1.0. There is no support in LMDB 1.0 for operating directly on v0.9 DB files.


Features:

- Page-level checksum
- Page-level encryption

Encryption is especially what we want with Kong.
